### PR TITLE
Add CRUD functionality for /plants endpoint

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -47,6 +47,17 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<version>42.7.1</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/server/src/main/java/com/leafandlife/leafandlife_backend/controller/PingController.java
+++ b/server/src/main/java/com/leafandlife/leafandlife_backend/controller/PingController.java
@@ -1,4 +1,4 @@
-package com.leafandlife.leafandlife_backend;
+package com.leafandlife.leafandlife_backend.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;

--- a/server/src/main/java/com/leafandlife/leafandlife_backend/controller/PlantController.java
+++ b/server/src/main/java/com/leafandlife/leafandlife_backend/controller/PlantController.java
@@ -1,0 +1,27 @@
+package com.leafandlife.leafandlife_backend.controller;
+
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+import com.leafandlife.leafandlife_backend.repository.PlantRepository;
+import com.leafandlife.leafandlife_backend.model.Plant;
+
+@RestController
+@RequestMapping("/plants")
+public class PlantController {
+
+    private final PlantRepository repository;
+
+    public PlantController(PlantRepository repository) {
+        this.repository = repository;
+    }
+
+    @GetMapping
+    public List<Plant> getAllPlants() {
+        return repository.findAll();
+    }
+
+    @PostMapping
+    public Plant addPlant(@RequestBody Plant plant) {
+        return repository.save(plant);
+    }
+}

--- a/server/src/main/java/com/leafandlife/leafandlife_backend/model/Plant.java
+++ b/server/src/main/java/com/leafandlife/leafandlife_backend/model/Plant.java
@@ -1,0 +1,48 @@
+package com.leafandlife.leafandlife_backend.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class Plant {
+
+    @Id
+    private Long id;
+    private String name;
+    private String type;
+
+    // Constructors
+    public Plant() {
+    }
+
+    public Plant(Long id, String name, String type) {
+        this.id = id;
+        this.name = name;
+        this.type = type;
+    }
+
+    // Getters and setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+}

--- a/server/src/main/java/com/leafandlife/leafandlife_backend/model/Plant.java
+++ b/server/src/main/java/com/leafandlife/leafandlife_backend/model/Plant.java
@@ -1,33 +1,30 @@
 package com.leafandlife.leafandlife_backend.model;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 
 @Entity
 public class Plant {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     private String name;
     private String type;
 
-    // Constructors
     public Plant() {
     }
 
-    public Plant(Long id, String name, String type) {
-        this.id = id;
+    public Plant(String name, String type) {
         this.name = name;
         this.type = type;
     }
 
-    // Getters and setters
     public Long getId() {
         return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
     }
 
     public String getName() {

--- a/server/src/main/java/com/leafandlife/leafandlife_backend/repository/PlantRepository.java
+++ b/server/src/main/java/com/leafandlife/leafandlife_backend/repository/PlantRepository.java
@@ -1,0 +1,7 @@
+package com.leafandlife.leafandlife_backend.repository;
+
+import com.leafandlife.leafandlife_backend.model.Plant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlantRepository extends JpaRepository<Plant, Long> {
+}

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -1,1 +1,8 @@
 spring.application.name=leafandlife-backend
+spring.datasource.url=jdbc:postgresql://localhost:5432/leafandlife_db
+spring.datasource.username=postgres
+spring.datasource.password=temp_password
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
Add CRUD functionality for /plants endpoint and test with local Postgres server
- Add PlantController to handle HTTP requests for plants
- Add Plant model to represent plant entities
- Add PlantRepository for database interactions
- add PostgreSQL and JPA dependencies to pom.xml
- add application.properties for datasource and JPA configuration
- move pingController to /controller 